### PR TITLE
CIR and Encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "enc"
+version = "0.1.0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,10 +74,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cir"
 version = "0.1.0"
-dependencies = [
- "hand",
- "ual",
-]
 
 [[package]]
 name = "config"
@@ -172,6 +168,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 name = "hand"
 version = "0.1.0"
 dependencies = [
+ "cir",
  "lexer",
  "parser",
 ]
@@ -628,6 +625,7 @@ dependencies = [
 name = "ual"
 version = "0.1.0"
 dependencies = [
+ "cir",
  "lexer",
  "miette",
  "parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cir"
+version = "0.1.0"
+dependencies = [
+ "hand",
+ "ual",
+]
+
+[[package]]
 name = "config"
 version = "0.1.0"
 dependencies = [
@@ -121,6 +129,13 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "enc"
 version = "0.1.0"
+dependencies = [
+ "cir",
+ "hand",
+ "matcher",
+ "ual",
+ "ual-derive",
+]
 
 [[package]]
 name = "equivalent"
@@ -212,9 +227,9 @@ dependencies = [
 name = "matcher"
 version = "0.1.0"
 dependencies = [
+ "cir",
  "hand",
  "modular-bitfield",
- "parser",
  "trie-rs",
  "ual",
  "ual-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cir"
 version = "0.1.0"
+dependencies = [
+ "kinded",
+]
 
 [[package]]
 name = "config"
@@ -83,6 +86,15 @@ dependencies = [
  "serde",
  "toml",
  "walkdir",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -194,6 +206,27 @@ name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
+name = "kinded"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4bdbb2f423660b19f0e9f7115182214732d8dd5f840cd0a3aee3e22562f34c"
+dependencies = [
+ "kinded_macros",
+]
+
+[[package]]
+name = "kinded_macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13b4ddc5dcb32f45dac3d6f606da2a52fdb9964a18427e63cd5ef6c0d13288d"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
+]
 
 [[package]]
 name = "lexer"
@@ -656,6 +689,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +144,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 name = "enc"
 version = "0.1.0"
 dependencies = [
+ "byteorder",
  "cir",
  "hand",
  "matcher",

--- a/crates/cir/Cargo.toml
+++ b/crates/cir/Cargo.toml
@@ -4,5 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-hand = { path = "../hand" }
-ual = { path = "../ual" }

--- a/crates/cir/Cargo.toml
+++ b/crates/cir/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "cir"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+hand = { path = "../hand" }
+ual = { path = "../ual" }

--- a/crates/cir/Cargo.toml
+++ b/crates/cir/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+kinded = "0.3"

--- a/crates/cir/src/hand.rs
+++ b/crates/cir/src/hand.rs
@@ -1,7 +1,7 @@
 use hand::AddressKind;
 use ual::TextRange;
 
-use super::Template;
+use super::CIR;
 
 pub(crate) struct HANDCursor<'a> {
     pos: usize,
@@ -18,7 +18,7 @@ impl<'a> HANDCursor<'a> {
         }
     }
 
-    pub(crate) fn process(&mut self) -> Vec<Template> {
+    pub(crate) fn process(&mut self) -> Vec<CIR> {
         let mut template = Vec::new();
 
         while let Some(frag) = self.bump() {
@@ -27,20 +27,20 @@ impl<'a> HANDCursor<'a> {
                     let text = self.resolve(range);
                     assert!(text.is_ascii());
                     for c in text.bytes() {
-                        template.push(Template::ident(c));
+                        template.push(CIR::ident(c));
                     }
                     continue;
                 }
-                hand::Fragment::Register(_) => Template::register(),
-                hand::Fragment::RegisterList(_) => Template::register_list(),
-                hand::Fragment::Number(_) => Template::number(),
+                hand::Fragment::Register(_) => CIR::register(),
+                hand::Fragment::RegisterList(_) => CIR::register_list(),
+                hand::Fragment::Number(_) => CIR::number(),
                 hand::Fragment::Address(kind) => match kind {
-                    AddressKind::Offset => Template::offset_address(),
-                    AddressKind::PreIndex => Template::pre_index_address(),
-                    AddressKind::PostIndex => Template::post_index_address(),
+                    AddressKind::Offset => CIR::offset_address(),
+                    AddressKind::PreIndex => CIR::pre_index_address(),
+                    AddressKind::PostIndex => CIR::post_index_address(),
                 },
-                hand::Fragment::ShiftKind(_) => Template::shift(),
-                hand::Fragment::Bang => Template::bang(),
+                hand::Fragment::ShiftKind(_) => CIR::shift(),
+                hand::Fragment::Bang => CIR::bang(),
                 hand::Fragment::Label(_) => continue,
             };
 

--- a/crates/cir/src/lib.rs
+++ b/crates/cir/src/lib.rs
@@ -1,24 +1,22 @@
 //! Common Immediate Representation
 
-mod hand;
-mod ual;
-
-pub(crate) use hand::HANDCursor;
-pub(crate) use ual::UALCursor;
+pub trait Convert {
+    fn to_cir(&self) -> Vec<CIR>;
+}
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct CIR(Inner);
 
-impl CIR {
-    pub fn from_hand(parse: &::hand::ParseResult) -> Vec<CIR> {
-        HANDCursor::new(parse.source(), parse.fragments()).process()
-    }
+// impl CIR {
+//     pub fn from_hand(parse: &::hand::ParseResult) -> Vec<CIR> {
+//         HANDCursor::new(parse.source(), parse.fragments()).process()
+//     }
 
-    pub fn from_ual<S: ::ual::Source>(parse: &::ual::Pattern<S>) -> Vec<CIR> {
-        UALCursor::new(parse.source(), parse.fragments()).process()
-    }
-}
+//     pub fn from_ual<S: ::ual::Source>(parse: &::ual::Pattern<S>) -> Vec<CIR> {
+//         UALCursor::new(parse.source(), parse.fragments()).process()
+//     }
+// }
 
 #[rustfmt::skip]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]

--- a/crates/cir/src/lib.rs
+++ b/crates/cir/src/lib.rs
@@ -8,16 +8,6 @@ pub trait Convert {
 #[repr(transparent)]
 pub struct CIR(Inner);
 
-// impl CIR {
-//     pub fn from_hand(parse: &::hand::ParseResult) -> Vec<CIR> {
-//         HANDCursor::new(parse.source(), parse.fragments()).process()
-//     }
-
-//     pub fn from_ual<S: ::ual::Source>(parse: &::ual::Pattern<S>) -> Vec<CIR> {
-//         UALCursor::new(parse.source(), parse.fragments()).process()
-//     }
-// }
-
 #[rustfmt::skip]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[repr(u8)]

--- a/crates/cir/src/lib.rs
+++ b/crates/cir/src/lib.rs
@@ -4,8 +4,7 @@ pub trait Convert {
     fn to_cir(&self) -> Vec<CIR>;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[derive(kinded::Kinded)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, kinded::Kinded)]
 #[kinded(derive(PartialOrd, Ord, Hash))]
 pub enum CIR {
     Char(char),
@@ -61,7 +60,7 @@ pub enum Condition {
     GE = 0b1010,
     /// Signed less than
     LT = 0b1011,
-    /// Signed greater than 
+    /// Signed greater than
     GT = 0b1100,
     /// Signed less than or equal
     LE = 0b1101,

--- a/crates/cir/src/ual.rs
+++ b/crates/cir/src/ual.rs
@@ -1,6 +1,6 @@
 use ual::{lowering::AddressKind, TextRange};
 
-use super::Template;
+use super::CIR;
 
 use ual::lowering::Fragment as UAL;
 use ual::lowering::Special;
@@ -20,7 +20,7 @@ impl<'a> UALCursor<'a> {
         }
     }
 
-    pub(crate) fn process(&mut self) -> Vec<Template> {
+    pub(crate) fn process(&mut self) -> Vec<CIR> {
         let mut template = Vec::new();
 
         while let Some(frag) = self.bump() {
@@ -29,24 +29,24 @@ impl<'a> UALCursor<'a> {
                     let text = self.resolve(range);
                     assert!(text.is_ascii());
                     for c in text.bytes() {
-                        template.push(Template::ident(c));
+                        template.push(CIR::ident(c));
                     }
                     continue;
                 }
                 UAL::Special(special) => match special {
-                    Special::Register(_) => Template::register(),
-                    Special::Registers => Template::register_list(),
-                    Special::Condition => Template::condition(),
+                    Special::Register(_) => CIR::register(),
+                    Special::Registers => CIR::register_list(),
+                    Special::Condition => CIR::condition(),
                     Special::Const | Special::Immediate => self.number(),
-                    Special::Shift => Template::shift(),
+                    Special::Shift => CIR::shift(),
                     Special::Label => continue,
                 },
                 UAL::Address(kind) => match kind {
-                    AddressKind::Offset => Template::offset_address(),
-                    AddressKind::PreIndex => Template::pre_index_address(),
-                    AddressKind::PostIndex => Template::post_index_address(),
+                    AddressKind::Offset => CIR::offset_address(),
+                    AddressKind::PreIndex => CIR::pre_index_address(),
+                    AddressKind::PostIndex => CIR::post_index_address(),
                 },
-                UAL::Byte(b'!') => Template::bang(),
+                UAL::Byte(b'!') => CIR::bang(),
                 UAL::Byte(b'#') => self.number(),
                 UAL::Byte(_) => continue,
             };
@@ -57,12 +57,12 @@ impl<'a> UALCursor<'a> {
         template
     }
 
-    fn number(&mut self) -> Template {
+    fn number(&mut self) -> CIR {
         assert!(matches!(
             self.bump(),
             Some(UAL::Special(Special::Const | Special::Immediate))
         ));
-        Template::number()
+        CIR::number()
     }
 
     fn resolve(&self, range: TextRange) -> &str {

--- a/crates/enc/Cargo.toml
+++ b/crates/enc/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "enc"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/crates/enc/Cargo.toml
+++ b/crates/enc/Cargo.toml
@@ -4,3 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+hand = { path = "../hand" }
+matcher = { path = "../matcher" }
+cir ={ path = "../cir" }
+
+byteorder = "1.5.0"
+
+[dev-dependencies]
+ual = { path = "../ual" }
+ual-derive = { path = "../ual-derive" }

--- a/crates/enc/src/encoder.rs
+++ b/crates/enc/src/encoder.rs
@@ -1,0 +1,41 @@
+use std::marker::PhantomData;
+
+use byteorder::{ByteOrder, WriteBytesExt, BE, LE};
+
+pub struct Encoder<ORDER> {
+    buffer: Vec<u8>,
+    _order: PhantomData<ORDER>,
+}
+
+impl<ORDER> Encoder<ORDER> {
+    pub fn buffer(&self) -> &[u8] {
+        &self.buffer
+    }
+}
+
+impl Encoder<BE> {
+    pub fn new_be() -> Self {
+        Self::new()
+    }
+}
+
+impl Encoder<LE> {
+    pub fn new_le() -> Self {
+        Self::new()
+    }
+}
+
+impl<ORDER: ByteOrder> Encoder<ORDER> {
+    fn new() -> Self {
+        Self {
+            buffer: Vec::new(),
+            _order: PhantomData,
+        }
+    }
+
+    pub fn push(&mut self, data: u32) {
+        self.buffer
+            .write_u32::<ORDER>(data)
+            .expect("Buffer can be written to");
+    }
+}

--- a/crates/enc/src/encoder.rs
+++ b/crates/enc/src/encoder.rs
@@ -2,6 +2,8 @@ use std::marker::PhantomData;
 
 use byteorder::{ByteOrder, WriteBytesExt, BE, LE};
 
+use crate::Word;
+
 pub struct Encoder<ORDER> {
     buffer: Vec<u8>,
     _order: PhantomData<ORDER>,
@@ -33,9 +35,9 @@ impl<ORDER: ByteOrder> Encoder<ORDER> {
         }
     }
 
-    pub fn push(&mut self, data: u32) {
+    pub fn push(&mut self, word: Word) {
         self.buffer
-            .write_u32::<ORDER>(data)
+            .write_u32::<ORDER>(word.get())
             .expect("Buffer can be written to");
     }
 }

--- a/crates/enc/src/lib.rs
+++ b/crates/enc/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 mod encoder;
 mod schema;
 mod word;

--- a/crates/enc/src/lib.rs
+++ b/crates/enc/src/lib.rs
@@ -1,0 +1,78 @@
+mod encoder;
+mod schema;
+pub mod variable;
+
+pub use schema::*;
+
+use cir::CIR;
+
+pub trait Encodable {
+    fn cir(&self) -> &[CIR];
+    fn schema(&self) -> Schema;
+}
+
+pub fn encode_instruction(encodable: &dyn Encodable, obj: &[CIR]) -> u32 {
+    let Schema { base, variables } = encodable.schema();
+    let pattern = &encodable.cir();
+
+    let mut bits = base;
+
+    for var in variables.into_iter().filter_map(|mut var| var.take()) {
+        let encoded = if let Some(value) = variable::find(var.name, pattern, obj) {
+            var.name.encode_with_ir(value)
+        } else if let Some(default) = var.name.has_default() {
+            default
+        } else {
+            panic!(
+                "failed to find '{:?}' in obj, perhaps you have defined your schema incorrectly",
+                var.name
+            );
+        };
+
+        bits |= encoded << var.low;
+    }
+
+    bits
+}
+
+#[test]
+fn api() {
+    use cir::Convert;
+    use std::sync::LazyLock;
+    use ual::UalSyntax;
+    use ual_derive::UAL;
+
+    #[derive(UAL, Clone)]
+    #[ual = "ADD <Rd>, <Rn>, #<const>"]
+    struct AddImm;
+
+    impl Encodable for AddImm {
+        fn cir(&self) -> &[CIR] {
+            static CIR: LazyLock<Vec<CIR>> = LazyLock::new(|| AddImm::PATTERN.to_cir());
+            &CIR
+        }
+
+        fn schema(&self) -> Schema {
+            const { schema([COND, 0, 0, 1, 0, 1, 0, 0, S, R('n'), R('d'), IMM12]) }
+        }
+    }
+
+    let mut p = matcher::Patterns::new();
+    p.push(Box::new(AddImm) as Box<dyn Encodable>, AddImm.cir());
+    let matcher = p.finish();
+
+    // TODO: ensure that they are a matched pair
+    // by having a function that does so
+    // Matched(pattern: &[CIR], obj: &[CIR])
+    let text = "ADD r1, r1, #1".into();
+    let hand = hand::parse(text);
+    let hand_cir = hand.to_cir();
+    let pattern = matcher.find_match(&hand_cir).expect("pattern exists!");
+
+    let bits = encode_instruction(pattern.as_ref(), &hand_cir);
+
+    let mut enc = encoder::Encoder::new_be();
+    enc.push(bits);
+
+    eprintln!("{:#x?}", enc.buffer());
+}

--- a/crates/enc/src/lib.rs
+++ b/crates/enc/src/lib.rs
@@ -3,6 +3,7 @@ mod schema;
 pub mod variable;
 
 pub use schema::*;
+pub use encoder::Encoder;
 
 use cir::CIR;
 

--- a/crates/enc/src/schema.rs
+++ b/crates/enc/src/schema.rs
@@ -1,0 +1,106 @@
+use crate::variable::{Variable, VariableDef};
+
+/// Describes what variables are needed and which bits they fill.
+pub struct Schema {
+    pub(crate) base: u32,
+    // slots for 8 variables
+    pub(crate) variables: [Option<VariableDef>; 8],
+}
+
+impl std::fmt::Debug for Schema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Schema(")?;
+        write!(f, "{:032b}", self.base)?;
+        if self.variables.first().is_some_and(|it| it.is_some()) {
+            write!(f, ", {{ ")?;
+            for def in self.variables.iter().filter(|it| it.is_some()).rev() {
+                let Some(VariableDef { name, high, low }) = def else {
+                    unreachable!()
+                };
+                match name {
+                    Variable::Rn => write!(f, "Rn")?,
+                    Variable::Rm => write!(f, "Rm")?,
+                    Variable::Rt => write!(f, "Rt")?,
+                    Variable::Rd => write!(f, "Rd")?,
+                    Variable::RegisterList => write!(f, "registers")?,
+                    Variable::Signed => write!(f, "S")?,
+                    Variable::Condition => write!(f, "cond")?,
+                    Variable::Stype => write!(f, "stype")?,
+                    Variable::Imm5 => write!(f, "imm5")?,
+                    Variable::Imm12 => write!(f, "imm12")?,
+                    Variable::Imm24 => write!(f, "imm24")?,
+                }
+                write!(f, "({},{})", high, low)?;
+                write!(f, " ")?;
+            }
+            write!(f, "}}")?;
+        }
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+pub const fn arg(name: u32, position: u32) -> u64 {
+    (name as u64) << 32 | position as u64
+}
+
+pub const fn schema<const LN: usize>(layout: [u32; LN]) -> Schema {
+    assert!(LN <= 32);
+
+    let mut variables: [Option<VariableDef>; 8] = [const { None }; 8];
+
+    let mut base = 0x0;
+
+    let mut var_idx = 0;
+    let mut bit = 0;
+
+    let mut i = LN;
+    while i != 0 {
+        i = i.saturating_sub(1);
+        let curr = layout[i];
+
+        let (bit_len, set_var) = match curr {
+            0 => (1, None),
+            1 => {
+                base |= 1 << bit;
+                (1, None)
+            }
+            COND => (4, Some(Variable::Condition)),
+            S => (1, Some(Variable::Signed)),
+            IMM12 => (12, Some(Variable::Imm12)),
+            x if x == R('n') => (4, Some(Variable::Rn)),
+            x if x == R('m') => (4, Some(Variable::Rm)),
+            x if x == R('d') => (4, Some(Variable::Rd)),
+            x if x == R('t') => (4, Some(Variable::Rt)),
+            _ => panic!("Unknown bit pattern in Schema"),
+        };
+
+        if let Some(name) = set_var {
+            variables[var_idx] = Some(VariableDef {
+                name,
+                high: bit + bit_len,
+                low: bit,
+            });
+            var_idx += 1;
+        }
+
+        bit += bit_len;
+    }
+
+    assert!(bit == 32, "Incorrect number of bits to build a Schema");
+
+    Schema { base, variables }
+}
+
+pub const COND: u32 = 1_u32 << 31;
+
+pub const S: u32 = 1_u32 << 30;
+
+pub const IMM12: u32 = 1_u32 << 29;
+
+#[allow(non_snake_case)]
+pub const fn R(x: char) -> u32 {
+    assert!(x.is_ascii());
+    let x = (x as u8) as u32;
+    (1_u32 << 28) + x
+}

--- a/crates/enc/src/tests.rs
+++ b/crates/enc/src/tests.rs
@@ -1,0 +1,32 @@
+mod load_store;
+mod data;
+mod multi_load_store;
+
+use super::*;
+use cir::Convert;
+use std::sync::LazyLock;
+use ual::UalSyntax;
+use ual_derive::UAL;
+
+macro_rules! impl_encodable {
+    ($target:ident, [$($t:expr),*]) => {
+        impl Encodable for $target {
+            fn cir(&self) -> &[CIR] {
+                static CIR: LazyLock<Vec<CIR>> = LazyLock::new(|| $target::PATTERN.to_cir());
+                &CIR
+            }
+        
+            fn schema(&self) -> Schema {
+                const { schema([ $($t),* ]) }
+            }
+        }
+    };
+}
+
+pub(crate) use impl_encodable;
+
+fn single_pattern(enc: Box<dyn Encodable>) -> matcher::Matcher<Box<dyn Encodable>> {
+    let mut p = matcher::Patterns::new();
+    p.push(enc, |enc| enc.cir());
+    p.finish()
+}

--- a/crates/enc/src/tests/data.rs
+++ b/crates/enc/src/tests/data.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+#[derive(UAL, Clone)]
+#[ual = "ADD <Rd>, <Rn>, #<const>"]
+struct AddImm;
+
+impl_encodable!(AddImm, [COND, 0, 0, 1, 0, 1, 0, 0, S, R('n'), R('d'), IMM12]);
+
+#[test]
+fn add_imm() {
+    let matcher = single_pattern(Box::new(AddImm));
+
+    let text = "ADD r0, r0, #0".into();
+    let hand = hand::parse(text);
+    let hand_cir = hand.to_cir();
+    let pair = matcher::match_pair(&matcher, &hand_cir).expect("Correct pattern");
+
+    let bits = encode_instruction(pair.value().as_ref(), pair.matched());
+
+    assert_eq!(bits, Word(0b1110_0010_1000_0000_0000_0000_0000_0000));
+}

--- a/crates/enc/src/tests/load_store.rs
+++ b/crates/enc/src/tests/load_store.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+#[derive(UAL, Clone)]
+#[ual = "LDR <Rt>, [<Rn>, #<imm>]!"]
+struct LdrImmPreIndex;
+
+impl_encodable!(LdrImmPreIndex, [COND, 0, 1, 0, P, U, 0, W, 1, R('n'), R('t'), IMM12]);
+
+#[test]
+fn ldr_imm_preidx() {
+    let matcher = single_pattern(Box::new(LdrImmPreIndex));
+
+    let text = "LDR r0, [r1, #1]!".into();
+    let hand = hand::parse(text);
+    let hand_cir = hand.to_cir();
+    let pair = matcher::match_pair(&matcher, &hand_cir).expect("Correct pattern");
+
+    let bits = encode_instruction(pair.value().as_ref(), pair.matched());
+
+    assert_eq!(bits, Word(0b1110_0101_1011_0001_0000_0000_0000_0001));
+}
+
+#[derive(UAL, Clone)]
+#[ual = "LDR <Rt>, [<Rn>, <Rm>, <shift>]!"]
+struct LdrRegPreIndex;
+
+impl_encodable!(
+    LdrRegPreIndex,
+    [COND, 0, 1, 1, P, U, 0, W, 1, R('n'), R('t'), IMM5, STYPE, 0, R('m')]
+);
+
+#[test]
+fn ldr_reg_preidx() {
+    let matcher = single_pattern(Box::new(LdrRegPreIndex));
+
+    let text = "LDR r0, [r1, r2, LSL #1]!".into();
+    let hand = hand::parse(text);
+    let hand_cir = hand.to_cir();
+    let pair = matcher::match_pair(&matcher, &hand_cir).expect("pattern exists!");
+
+    let bits = encode_instruction(pair.value().as_ref(), pair.matched());
+
+    assert_eq!(bits, Word(0b1110_0111_1011_0001_0000_0000_1000_0010));
+}
+
+// TODO: labels
+// #[derive(UAL, Clone)]
+// #[ual = "LDR <Rt>, <label>"]
+// struct LdrImmLit;
+
+// impl_encodable!(LdrImmLit, [COND, 0, 1, 0, P, U, 0, W, 1, 1, 1, 1, 1, R('t'), LABEL]);
+
+// #[test]
+// fn ldr_imm_lit() {
+//     let matcher = single_pattern(Box::new(LdrImmLit));
+
+//     let text = "LDR r0, label!".into();
+//     let hand = hand::parse(text);
+//     let hand_cir = hand.to_cir();
+//     let pair = matcher::match_pair(&matcher, &hand_cir).expect("pattern exists!");
+
+//     let bits = encode_instruction(pair.value().as_ref(), pair.matched());
+
+//     eprintln!("{:032b}", bits);
+
+//     assert_eq!(bits, 0b1110_0101_1011_0001_0000_0000_0000_0001);
+// }

--- a/crates/enc/src/tests/multi_load_store.rs
+++ b/crates/enc/src/tests/multi_load_store.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+#[derive(UAL, Clone)]
+#[ual = "LDM <Rn>, <registers>"]
+struct Ldm;
+
+impl_encodable!(Ldm, [COND, 1, 0, 0, 0, 1, 0, W, 1, R('n'), REGISTER_LIST]);
+
+#[test]
+fn ldm() {
+    let matcher = single_pattern(Box::new(Ldm));
+
+    let text = "LDM r0, {r1}".into();
+    let hand = hand::parse(text);
+    let hand_cir = hand.to_cir();
+    let pair = matcher::match_pair(&matcher, &hand_cir).expect("Correct pattern");
+
+    let bits = encode_instruction(pair.value().as_ref(), pair.matched());
+
+    assert_eq!(bits, Word(0b1110_1000_1001_0000_0000_0000_0000_0010));
+}

--- a/crates/enc/src/variable.rs
+++ b/crates/enc/src/variable.rs
@@ -1,0 +1,95 @@
+use cir::{Condition, CIR};
+
+const N: u32 = 'n' as u32;
+const M: u32 = 'm' as u32;
+const T: u32 = 't' as u32;
+const D: u32 = 'd' as u32;
+
+pub fn find(name: Variable, pattern: &[CIR], obj: &[CIR]) -> Option<CIR> {
+    let pos = pattern.iter().position(|ir| name == *ir)?;
+    obj.get(pos).copied()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum Variable {
+    /// Rn
+    Rn,
+    /// Rm
+    Rm,
+    /// Rt
+    Rt,
+    /// Rd
+    Rd,
+    /// registers
+    RegisterList,
+    /// S
+    Signed,
+    /// cond
+    Condition,
+    /// stype
+    Stype,
+    /// imm5
+    Imm5,
+    /// imm12
+    Imm12,
+    /// imm24
+    Imm24,
+}
+
+impl Variable {
+    /// `value` comes from the obj, not the patterns
+    ///
+    /// # Panics
+    ///
+    /// If the pair are not encodable
+    pub fn encode_with_ir(&self, value: CIR) -> u32 {
+        match (&self, value) {
+            (Variable::Rn, CIR::Register(x)) => x,
+            (Variable::Rm, CIR::Register(x)) => x,
+            (Variable::Rt, CIR::Register(x)) => x,
+            (Variable::Rd, CIR::Register(x)) => x,
+            (Variable::RegisterList, CIR::RegisterList(x)) => x as u32,
+            (Variable::Signed, CIR::Char('S')) => true as u32,
+            (Variable::Condition, CIR::Condition(cond)) => cond as u32,
+            (Variable::Stype, CIR::Shift(shift)) => shift as u32,
+            (Variable::Imm5, CIR::Number(x)) => x,
+            (Variable::Imm12, CIR::Number(x)) => x,
+            (Variable::Imm24, CIR::Number(x)) => x,
+            _ => panic!("Pair not encodable"),
+        }
+    }
+
+    pub fn has_default(&self) -> Option<u32> {
+        match self {
+            Variable::Signed => Some(false as u32),
+            Variable::Condition => Some(self.encode_with_ir(CIR::Condition(Condition::AL))),
+            _ => None,
+        }
+    }
+}
+
+impl PartialEq<cir::CIR> for Variable {
+    fn eq(&self, other: &cir::CIR) -> bool {
+        matches!(
+            (self, other),
+            (Variable::Rn, CIR::Register(N))
+                | (Variable::Rm, CIR::Register(M))
+                | (Variable::Rt, CIR::Register(T))
+                | (Variable::Rd, CIR::Register(D))
+                | (Variable::RegisterList, CIR::RegisterList(_))
+                | (Variable::Signed, CIR::Char('S'))
+                | (Variable::Condition, CIR::Condition(_))
+                | (Variable::Stype, CIR::Shift(_))
+                | (Variable::Imm5, CIR::Number(_))
+                | (Variable::Imm12, CIR::Number(_))
+                | (Variable::Imm24, CIR::Number(_))
+        )
+    }
+}
+
+pub struct VariableDef {
+    pub(crate) name: Variable,
+    pub(crate) high: u8,
+    pub(crate) low: u8,
+}

--- a/crates/enc/src/word.rs
+++ b/crates/enc/src/word.rs
@@ -1,0 +1,59 @@
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct Word(pub(crate) u32);
+
+impl Word {
+    pub const fn get(&self) -> u32 {
+        self.0
+    }
+}
+
+impl std::ops::Deref for Word {
+    type Target = u32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for Word {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let binary = format!("{:032b}", self.0);
+        let binary = binary.bytes().collect::<Vec<_>>();
+        let mut nibbles = binary.as_slice().chunks_exact(4);
+
+        write!(f, "0b")?;
+        for (i, n) in nibbles.by_ref().enumerate() {
+            let [a, b, c, d] = n else { unreachable!() };
+            fn to_char(x: u8) -> char {
+                char::from_u32(x as u32).unwrap()
+            }
+            write!(
+                f,
+                "{}{}{}{}",
+                to_char(*a),
+                to_char(*b),
+                to_char(*c),
+                to_char(*d)
+            )?;
+            if i != 7 {
+                write!(f, "_")?;
+            }
+        }
+
+        assert!(nibbles.remainder().is_empty());
+        Ok(())
+    }
+}
+
+impl PartialEq<u32> for Word {
+    fn eq(&self, other: &u32) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<Word> for u32 {
+    fn eq(&self, other: &Word) -> bool {
+        *other == *self
+    }
+}

--- a/crates/hand/Cargo.toml
+++ b/crates/hand/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 lexer = { path = "../lexer" }
 parser = { path = "../parser" }
+cir = { path = "../cir" }

--- a/crates/hand/src/lowering.rs
+++ b/crates/hand/src/lowering.rs
@@ -1,3 +1,5 @@
+mod cir;
+
 use parser::rowan::TextRange;
 
 use crate::ast::{self, AstToken};

--- a/crates/hand/src/lowering.rs
+++ b/crates/hand/src/lowering.rs
@@ -15,7 +15,7 @@ pub enum Fragment {
     Name(TextRange),
     Number(u32),
     Address(AddressKind),
-    ShiftKind(ShiftKind),
+    Shift(ShiftKind),
     Bang,
 }
 
@@ -116,23 +116,23 @@ fn lower_shift(frags: &mut Vec<Fragment>, shift: Option<ast::Shift>) {
     if let Some(kind) = shift.and_then(|shift| shift.kind()) {
         match kind {
             ast::ShiftKind::LSL { amount } => {
-                frags.push(Fragment::ShiftKind(ShiftKind::LSL));
+                frags.push(Fragment::Shift(ShiftKind::LSL));
                 lower_amount(frags, amount)
             }
             ast::ShiftKind::LSR { amount } => {
-                frags.push(Fragment::ShiftKind(ShiftKind::LSR));
+                frags.push(Fragment::Shift(ShiftKind::LSR));
                 lower_amount(frags, amount);
             }
             ast::ShiftKind::ASR { amount } => {
-                frags.push(Fragment::ShiftKind(ShiftKind::ASR));
+                frags.push(Fragment::Shift(ShiftKind::ASR));
                 lower_amount(frags, amount);
             }
             ast::ShiftKind::ROR { amount } => {
-                frags.push(Fragment::ShiftKind(ShiftKind::ROR));
+                frags.push(Fragment::Shift(ShiftKind::ROR));
                 lower_amount(frags, amount);
             }
             ast::ShiftKind::RRX => {
-                frags.push(Fragment::ShiftKind(ShiftKind::RRX));
+                frags.push(Fragment::Shift(ShiftKind::RRX));
                 lower_amount(frags, None)
             }
         }

--- a/crates/matcher/Cargo.toml
+++ b/crates/matcher/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-hand = { path = "../hand" }
-ual = { path = "../ual" }
-parser = { path = "../parser" }
+cir = { path = "../cir" }
 
 trie-rs = "0.4.2"
 modular-bitfield = "0.11.2"
 
 [dev-dependencies]
 ual-derive = { path = "../ual-derive" }
+ual = { path = "../ual" }
+hand = { path = "../hand" }

--- a/crates/matcher/src/lib.rs
+++ b/crates/matcher/src/lib.rs
@@ -18,7 +18,8 @@ impl<V> Patterns<V> {
         }
     }
 
-    pub fn push(&mut self, pattern: V, cir: &[CIR]) {
+    pub fn push(&mut self, mut pattern: V, cir: impl FnOnce(&mut V) -> &[CIR]) {
+        let cir = cir(&mut pattern);
         self.inner
             .push(cir.iter().map(CIR::kind).collect::<Vec<_>>(), pattern);
     }
@@ -60,9 +61,9 @@ fn api() {
     struct LdrImm;
 
     let mut p = Patterns::new();
-    p.push(1, &AddImm::PATTERN.to_cir());
-    p.push(2, &AddReg::PATTERN.to_cir());
-    p.push(3, &LdrImm::PATTERN.to_cir());
+    p.push(1, |_| AddImm::PATTERN.to_cir().leak());
+    p.push(2, |_| AddReg::PATTERN.to_cir().leak());
+    p.push(3, |_| LdrImm::PATTERN.to_cir().leak());
 
     let t = p.finish();
 

--- a/crates/matcher/src/lib.rs
+++ b/crates/matcher/src/lib.rs
@@ -33,8 +33,7 @@ pub struct Matcher<V> {
     inner: Trie<CIR, V>,
 }
 
-impl<V> Matcher<V>
-{
+impl<V> Matcher<V> {
     pub fn find_match(&self, cir: &[CIR]) -> Option<&V> {
         self.inner.exact_match(cir)
     }
@@ -42,6 +41,7 @@ impl<V> Matcher<V>
 
 #[test]
 fn api() {
+    use cir::Convert;
     use ual::UalSyntax;
     use ual_derive::UAL;
 
@@ -58,25 +58,21 @@ fn api() {
     struct LdrImm;
 
     let mut p = Patterns::new();
-    p.push(1, &CIR::from_ual(&AddImm::PATTERN));
-    p.push(2, &CIR::from_ual(&AddReg::PATTERN));
-    p.push(3, &CIR::from_ual(&LdrImm::PATTERN));
+    p.push(1, &AddImm::PATTERN.to_cir());
+    p.push(2, &AddReg::PATTERN.to_cir());
+    p.push(3, &LdrImm::PATTERN.to_cir());
 
     let t = p.finish();
 
     let text = "ADD r0, r1, #10".into();
     let hand = hand::parse(text);
-    let pattern = t
-        .find_match(&CIR::from_hand(&hand))
-        .expect("pattern exists!");
+    let pattern = t.find_match(&hand.to_cir()).expect("pattern exists!");
 
     assert_eq!(*pattern, 1);
 
     let text = "LDR r0, [r1, #1]".into();
     let hand = hand::parse(text);
-    let pattern = t
-        .find_match(&CIR::from_hand(&hand))
-        .expect("pattern exists!");
+    let pattern = t.find_match(&hand.to_cir()).expect("pattern exists!");
 
     assert_eq!(*pattern, 3);
 }

--- a/crates/matcher/src/lib.rs
+++ b/crates/matcher/src/lib.rs
@@ -1,81 +1,48 @@
-mod template;
-
-use std::{
-    any::{Any, TypeId},
-    collections::HashMap,
-};
-
-use template::{UALCursor, *};
+use cir::CIR;
 use trie_rs::map::{Trie, TrieBuilder};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(transparent)]
-pub struct Match(u32);
-
-pub struct Patterns {
-    used_markers: HashMap<TypeId, Match>,
-    next_index: u32,
-    inner: TrieBuilder<Template, Match>,
+pub struct Patterns<V> {
+    inner: TrieBuilder<CIR, V>,
 }
 
-impl Patterns {
+impl<V> Patterns<V> {
     pub fn new() -> Self {
         Self {
-            used_markers: HashMap::new(),
-            next_index: 0_u32,
             inner: TrieBuilder::new(),
         }
     }
 
-    pub fn finish(self) -> Matcher {
+    pub fn finish(self) -> Matcher<V> {
         Matcher {
             inner: self.inner.build(),
         }
     }
 
-    pub fn push<T: ual::UalSyntax + Any>(&mut self, _: &T) -> Match {
-        // TrieBuilder won't change if you push the same T twice,
-        // so we need to ensure that we also give out the correct marker.
-        if let Some(marker) = self.used_markers.get(&TypeId::of::<T>()) {
-            return *marker;
-        }
-
-        let pattern = T::PATTERN;
-        let template = UALCursor::new(pattern.source(), pattern.fragments()).process();
-
-        let index = self.next_index();
-        self.inner.push(template, index);
-        self.used_markers.insert(TypeId::of::<T>(), index);
-        index
-    }
-
-    fn next_index(&mut self) -> Match {
-        let index = Match(self.next_index);
-        self.next_index += 1;
-        index
+    pub fn push(&mut self, pattern: V, cir: &[CIR]) {
+        self.inner.push(cir, pattern);
     }
 }
 
-impl Default for Patterns {
+impl<V> Default for Patterns<V> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-pub struct Matcher {
-    inner: Trie<Template, Match>,
+pub struct Matcher<V> {
+    inner: Trie<CIR, V>,
 }
 
-impl Matcher {
-    pub fn find_match(&self, hand: &hand::ParseResult) -> Option<Match> {
-        let template = HANDCursor::new(hand.source(), hand.fragments()).process();
-
-        self.inner.exact_match(&template).copied()
+impl<V> Matcher<V>
+{
+    pub fn find_match(&self, cir: &[CIR]) -> Option<&V> {
+        self.inner.exact_match(cir)
     }
 }
 
 #[test]
 fn api() {
+    use ual::UalSyntax;
     use ual_derive::UAL;
 
     #[derive(UAL)]
@@ -91,24 +58,25 @@ fn api() {
     struct LdrImm;
 
     let mut p = Patterns::new();
-    let add_imm = p.push(&AddImm);
-    let _add_reg = p.push(&AddReg);
-    let ldr_imm = p.push(&LdrImm);
-
-    let add_imm_2 = p.push(&AddImm);
-    assert_eq!(add_imm, add_imm_2);
+    p.push(1, &CIR::from_ual(&AddImm::PATTERN));
+    p.push(2, &CIR::from_ual(&AddReg::PATTERN));
+    p.push(3, &CIR::from_ual(&LdrImm::PATTERN));
 
     let t = p.finish();
 
     let text = "ADD r0, r1, #10".into();
     let hand = hand::parse(text);
-    let pattern = t.find_match(&hand).expect("pattern exists!");
+    let pattern = t
+        .find_match(&CIR::from_hand(&hand))
+        .expect("pattern exists!");
 
-    assert_eq!(pattern, add_imm);
+    assert_eq!(*pattern, 1);
 
     let text = "LDR r0, [r1, #1]".into();
     let hand = hand::parse(text);
-    let pattern = t.find_match(&hand).expect("pattern exists!");
+    let pattern = t
+        .find_match(&CIR::from_hand(&hand))
+        .expect("pattern exists!");
 
-    assert_eq!(pattern, ldr_imm);
+    assert_eq!(*pattern, 3);
 }

--- a/crates/matcher/src/lib.rs
+++ b/crates/matcher/src/lib.rs
@@ -2,7 +2,7 @@ use cir::CIR;
 use trie_rs::map::{Trie, TrieBuilder};
 
 pub struct Patterns<V> {
-    inner: TrieBuilder<CIR, V>,
+    inner: TrieBuilder<cir::CIRKind, V>,
 }
 
 impl<V> Patterns<V> {
@@ -19,7 +19,7 @@ impl<V> Patterns<V> {
     }
 
     pub fn push(&mut self, pattern: V, cir: &[CIR]) {
-        self.inner.push(cir, pattern);
+        self.inner.push(cir.iter().map(CIR::kind).collect::<Vec<_>>(), pattern);
     }
 }
 
@@ -30,12 +30,12 @@ impl<V> Default for Patterns<V> {
 }
 
 pub struct Matcher<V> {
-    inner: Trie<CIR, V>,
+    inner: Trie<cir::CIRKind, V>,
 }
 
 impl<V> Matcher<V> {
     pub fn find_match(&self, cir: &[CIR]) -> Option<&V> {
-        self.inner.exact_match(cir)
+        self.inner.exact_match(cir.iter().map(CIR::kind).collect::<Vec<_>>())
     }
 }
 

--- a/crates/matcher/src/lib.rs
+++ b/crates/matcher/src/lib.rs
@@ -42,6 +42,31 @@ impl<V> Matcher<V> {
     }
 }
 
+/// Convenience function that wraps matched values together.
+pub fn match_pair<'a, 'b, V>(
+    matcher: &'a Matcher<V>,
+    object: &'b [CIR],
+) -> Option<Match<'a, 'b, V>> {
+    let value = matcher.find_match(object)?;
+    Some(Match { value, matched: object })
+}
+
+#[derive(Debug)]
+pub struct Match<'a, 'b, V> {
+    value: &'a V,
+    matched: &'b [CIR],
+}
+
+impl<'a, 'b, V> Match<'a, 'b, V> {
+    pub fn value(&self) -> &V {
+        self.value
+    }
+    
+    pub fn matched(&self) -> &[CIR] {
+        self.matched
+    }
+}
+
 #[test]
 fn api() {
     use cir::Convert;

--- a/crates/matcher/src/lib.rs
+++ b/crates/matcher/src/lib.rs
@@ -19,7 +19,8 @@ impl<V> Patterns<V> {
     }
 
     pub fn push(&mut self, pattern: V, cir: &[CIR]) {
-        self.inner.push(cir.iter().map(CIR::kind).collect::<Vec<_>>(), pattern);
+        self.inner
+            .push(cir.iter().map(CIR::kind).collect::<Vec<_>>(), pattern);
     }
 }
 
@@ -35,7 +36,8 @@ pub struct Matcher<V> {
 
 impl<V> Matcher<V> {
     pub fn find_match(&self, cir: &[CIR]) -> Option<&V> {
-        self.inner.exact_match(cir.iter().map(CIR::kind).collect::<Vec<_>>())
+        self.inner
+            .exact_match(cir.iter().map(CIR::kind).collect::<Vec<_>>())
     }
 }
 

--- a/crates/ual/Cargo.toml
+++ b/crates/ual/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 [dependencies]
 lexer = { path = "../lexer" }
 parser = { path = "../parser" }
+cir = { path = "../cir" }
 thiserror = "1.0"
 miette = "7.2"

--- a/crates/ual/src/lib.rs
+++ b/crates/ual/src/lib.rs
@@ -27,7 +27,7 @@ pub enum UAL {}
 impl UAL {
     pub fn parse(text: Arc<str>) -> Result<Pattern<'static, Arc<str>>, Errors> {
         let tree = crate::grammar::parse(text.clone());
-        let root = dbg!(crate::ast::Root::cast(tree).expect("grammar starts at root"));
+        let root = crate::ast::Root::cast(tree).expect("grammar starts at root");
 
         let mut errors = Vec::new();
         crate::ast::validate(root.clone(), &mut errors);

--- a/crates/ual/src/lowering.rs
+++ b/crates/ual/src/lowering.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Fragment {
 #[derive(Clone, Copy)]
 pub enum Special {
     /// <Rn>
-    Register(u8),
+    Register(char),
     /// <registers>
     Registers,
     /// <c>
@@ -53,7 +53,7 @@ impl std::fmt::Debug for Special {
         match self {
             Self::Register(digit) => f
                 .debug_tuple("Register")
-                .field(&std::char::from_u32(*digit as u32).unwrap())
+                .field(&digit)
                 .finish(),
             Self::Registers => write!(f, "Registers"),
             Self::Condition => write!(f, "Condition"),
@@ -204,7 +204,7 @@ impl FromStr for Special {
         let s = s.to_lowercase();
 
         if let Some(rest) = s.strip_prefix('r') {
-            if let [c @ b'A'..=b'Z' | c @ b'a'..=b'z'] = rest.as_bytes() {
+            if let [c @ 'A'..='Z' | c @ 'a'..='z'] = rest.chars().collect::<Vec<_>>().as_slice() {
                 return Ok(Special::Register(*c));
             }
         }

--- a/crates/ual/src/lowering.rs
+++ b/crates/ual/src/lowering.rs
@@ -1,3 +1,5 @@
+mod cir;
+
 use std::{collections::VecDeque, str::FromStr};
 
 use lexer::Token;

--- a/crates/ual/src/lowering.rs
+++ b/crates/ual/src/lowering.rs
@@ -51,10 +51,7 @@ pub enum Special {
 impl std::fmt::Debug for Special {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Register(digit) => f
-                .debug_tuple("Register")
-                .field(&digit)
-                .finish(),
+            Self::Register(digit) => f.debug_tuple("Register").field(&digit).finish(),
             Self::Registers => write!(f, "Registers"),
             Self::Condition => write!(f, "Condition"),
             Self::Const => write!(f, "Const"),


### PR DESCRIPTION
Introduces a common immediate representation (`cir`) crate for simpler matching in `matcher`.
The `cir` also contains the correct "level" of information to be encoded into a binary format, which is the aim of this PR.

Instruction encoding is handled in the `enc` crate.
The encoding of an instruction is defined by a `Schema`.
This can then be matched against the instruction template to find the value of variables in the `Schema`.
Each variable is then encoded using this value and then collected into a single u32 value representing the encoded instruction.

An `Encoder` can then be used to push each instruction into a buffer, written in the appropriate byte order.