### PR TITLE
Lower labels to their PC offset

### DIFF
--- a/crates/cir/src/lib.rs
+++ b/crates/cir/src/lib.rs
@@ -13,6 +13,7 @@ pub enum CIR {
     Condition(Condition),
     Shift(Shift),
     Number(u32),
+    Label(i32),
     OffsetAddress,
     PreIndexAddress,
     PostIndexAddress,

--- a/crates/enc/src/schema.rs
+++ b/crates/enc/src/schema.rs
@@ -20,6 +20,7 @@ impl std::fmt::Debug for Schema {
                     unreachable!()
                 };
                 match name {
+                    Variable::Label => write!(f, "label")?,
                     Variable::Rn => write!(f, "Rn")?,
                     Variable::Rm => write!(f, "Rm")?,
                     Variable::Rt => write!(f, "Rt")?,
@@ -82,7 +83,7 @@ pub const fn schema<const LN: usize>(layout: [u32; LN]) -> Schema {
             x if x == R('t') => (4, Some(Variable::Rt)),
             IMM5 => (5, Some(Variable::Imm5)),
             IMM12 => (12, Some(Variable::Imm12)),
-            LABEL => (12, Some(Variable::Imm12)),
+            LABEL => (12, Some(Variable::Label)),
             REGISTER_LIST => (16, Some(Variable::RegisterList)),
             _ => panic!("Unknown bit pattern in Schema"),
         };

--- a/crates/enc/src/tests/load_store.rs
+++ b/crates/enc/src/tests/load_store.rs
@@ -75,25 +75,40 @@ fn ldr_reg_preidx() {
     assert_eq!(bits, Word(0b1110_0111_1011_0001_0000_0000_1000_0010));
 }
 
-// TODO: labels
-// #[derive(UAL, Clone)]
-// #[ual = "LDR <Rt>, <label>"]
-// struct LdrImmLit;
+struct LdrImmLit;
 
-// impl_encodable!(LdrImmLit, [COND, 0, 1, 0, P, U, 0, W, 1, 1, 1, 1, 1, R('t'), LABEL]);
+impl Pattern for LdrImmLit {
+    fn pattern(&self) -> &[CIR] {
+        use CIR::*;
+        static PATTERN: &[CIR] = &[
+            Char('L'),
+            Char('D'),
+            Char('R'),
+            Register('t' as u32),
+            Label(i32::MAX),
+        ];
+        PATTERN
+    }
+}
 
-// #[test]
-// fn ldr_imm_lit() {
-//     let matcher = single_pattern(Box::new(LdrImmLit));
+#[rustfmt::skip]
+impl_encodable!(
+    LdrImmLit,
+    [COND, 0, 1, 0, P, U, 0, W, 1, 1, 1, 1, 1, R('t'), LABEL]
+);
 
-//     let text = "LDR r0, label!".into();
-//     let hand = hand::parse(text);
-//     let hand_cir = hand.to_cir();
-//     let pair = matcher::match_pair(&matcher, &hand_cir).expect("pattern exists!");
+#[test]
+fn ldr_imm_lit() {
+    let matcher = single_pattern(Box::new(LdrImmLit));
 
-//     let bits = encode_instruction(pair.value().as_ref(), pair.matched());
+    let text = "label: LDR r0, label".into();
+    let hand = hand::parse(text);
+    let hand_cir = hand.to_cir();
+    let pair = matcher::match_pair(&matcher, &hand_cir).expect("pattern exists!");
 
-//     eprintln!("{:032b}", bits);
+    let bits = encode_instruction(pair.value().as_ref(), pair.matched());
 
-//     assert_eq!(bits, 0b1110_0101_1011_0001_0000_0000_0000_0001);
-// }
+    eprintln!("{:032?}", bits);
+
+    assert_eq!(bits, Word(0b1110_0101_0001_1111_0000_0000_0000_1000));
+}

--- a/crates/enc/src/variable.rs
+++ b/crates/enc/src/variable.rs
@@ -8,6 +8,8 @@ pub fn find(name: Variable, pattern: &[CIR], obj: &[CIR]) -> Option<CIR> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum Variable {
+    /// label
+    Label,
     /// Rn
     Rn,
     /// Rm
@@ -46,6 +48,7 @@ impl Variable {
     /// If the pair are not encodable
     pub fn encode_with_ir(&self, value: CIR) -> u32 {
         match (&self, value) {
+            (Variable::Label, CIR::Label(adr)) => adr as u32,
             (Variable::Rn, CIR::Register(x)) => x,
             (Variable::Rm, CIR::Register(x)) => x,
             (Variable::Rt, CIR::Register(x)) => x,
@@ -93,7 +96,8 @@ impl PartialEq<cir::CIR> for Variable {
 
         matches!(
             (self, other),
-            (Variable::Rn, CIR::Register(N))
+            (Variable::Label, CIR::Label(_))
+                | (Variable::Rn, CIR::Register(N))
                 | (Variable::Rm, CIR::Register(M))
                 | (Variable::Rt, CIR::Register(T))
                 | (Variable::Rd, CIR::Register(D))

--- a/crates/hand/src/lowering/cir.rs
+++ b/crates/hand/src/lowering/cir.rs
@@ -53,7 +53,7 @@ impl<'a> HANDCursor<'a> {
                     super::ShiftKind::RRX => cir::Shift::RRX,
                 }),
                 Fragment::Bang => CIR::Bang,
-                Fragment::Label(_) => continue,
+                Fragment::Label(adr) => CIR::Label(adr),
             };
 
             cir.push(part);


### PR DESCRIPTION
Labels now support lowering.

A pre-pass is used to compute the value of each defined label before an instruction.
The values are then used to calculate an offset from the PC which is used to lower into `CIR::Label(i32)`.
The PC offset has to be signed as there may be jumps backwards through code.