### PR TITLE
manual encoding through `Schema`

### DIFF
--- a/crates/enc/src/lib.rs
+++ b/crates/enc/src/lib.rs
@@ -23,7 +23,10 @@ pub fn encode_instruction(encodable: &dyn Encodable, obj: &[CIR]) -> Word {
 
     let mut bits = 0_u32;
 
-    for VariableDef { value, high, low, .. } in schema.variables() {
+    for VariableDef {
+        value, high, low, ..
+    } in schema.variables()
+    {
         bits |= value << low & range_mask(high, low);
     }
 
@@ -31,16 +34,8 @@ pub fn encode_instruction(encodable: &dyn Encodable, obj: &[CIR]) -> Word {
 }
 
 const fn range_mask(high: u8, low: u8) -> u32 {
-    let top = if high == 32 {
-        u32::MAX
-    } else {
-        1 << high
-    };
-    let bottom = if high == 32 && low == 0 {
-        0
-    } else {
-        1 << low
-    };
+    let top = if high == 32 { u32::MAX } else { 1 << high };
+    let bottom = if high == 32 && low == 0 { 0 } else { 1 << low };
 
-    top-bottom
+    top - bottom
 }

--- a/crates/enc/src/lib.rs
+++ b/crates/enc/src/lib.rs
@@ -15,29 +15,32 @@ pub use word::Word;
 use cir::CIR;
 
 pub trait Encodable: Pattern {
-    fn schema(&self) -> Schema;
+    fn schema(&self, obj: &[CIR]) -> Schema;
 }
 
 pub fn encode_instruction(encodable: &dyn Encodable, obj: &[CIR]) -> Word {
-    let Schema { base, variables } = encodable.schema();
-    let pattern = &encodable.pattern();
+    let schema = encodable.schema(obj);
 
-    let mut bits = base;
+    let mut bits = 0_u32;
 
-    for var in variables.into_iter().filter_map(|mut var| var.take()) {
-        let encoded = if let Some(value) = variable::find(var.name, pattern, obj) {
-            var.name.encode_with_ir(value)
-        } else if let Some(default) = var.name.has_default() {
-            default
-        } else {
-            panic!(
-                "failed to find '{:?}' in obj, perhaps you have defined your schema incorrectly",
-                var.name
-            );
-        };
-
-        bits |= encoded << var.low;
+    for VariableDef { value, high, low, .. } in schema.variables() {
+        bits |= value << low & range_mask(high, low);
     }
 
     Word(bits)
+}
+
+const fn range_mask(high: u8, low: u8) -> u32 {
+    let top = if high == 32 {
+        u32::MAX
+    } else {
+        1 << high
+    };
+    let bottom = if high == 32 && low == 0 {
+        0
+    } else {
+        1 << low
+    };
+
+    top-bottom
 }

--- a/crates/enc/src/tests.rs
+++ b/crates/enc/src/tests.rs
@@ -5,18 +5,7 @@ mod multi_load_store;
 use super::*;
 use cir::Convert;
 use matcher::Pattern;
-
-macro_rules! impl_encodable {
-    ($target:ident, [$($t:expr),*]) => {
-        impl Encodable for $target {
-            fn schema(&self) -> Schema {
-                const { schema([ $($t),* ]) }
-            }
-        }
-    };
-}
-
-pub(crate) use impl_encodable;
+use variable::Variable;
 
 fn single_pattern(enc: Box<dyn Encodable>) -> matcher::Matcher<Box<dyn Encodable>> {
     let mut p = matcher::Patterns::new();

--- a/crates/enc/src/tests/data.rs
+++ b/crates/enc/src/tests/data.rs
@@ -17,11 +17,18 @@ impl Pattern for AddImm {
     }
 }
 
-#[rustfmt::skip]
-impl_encodable!(
-    AddImm,
-    [COND, 0, 0, 1, 0, 1, 0, 0, S, R('n'), R('d'), IMM12]
-);
+impl Encodable for AddImm {
+    fn schema(&self, obj: &[CIR]) -> Schema {
+        Schema::new()
+            .cond()
+            .one(25)
+            .one(23)
+            .bit(Variable::Signed, obj[4] == CIR::Char('S'), 20)
+            .set(Variable::Rn, reg(5, obj), 20, 16)
+            .set(Variable::Rd, reg(4, obj), 16, 12)
+            .set(Variable::Imm12, imm12(6, obj), 12, 0)
+    }
+}
 
 #[test]
 fn add_imm() {

--- a/crates/enc/src/tests/multi_load_store.rs
+++ b/crates/enc/src/tests/multi_load_store.rs
@@ -16,8 +16,18 @@ impl Pattern for Ldm {
     }
 }
 
-#[rustfmt::skip]
-impl_encodable!(Ldm, [COND, 1, 0, 0, 0, 1, 0, W, 1, R('n'), REGISTER_LIST]);
+impl Encodable for Ldm {
+    fn schema(&self, obj: &[CIR]) -> Schema {
+        Schema::new()
+            .cond()
+            .one(27)
+            .one(23)
+            .bit(Variable::W, false, 21)
+            .one(20)
+            .set(Variable::Rn, reg(4, obj), 20, 16)
+            .set(Variable::RegisterList, register_list(5, obj), 16, 0)
+    }
+}
 
 #[test]
 fn ldm() {

--- a/crates/enc/src/variable.rs
+++ b/crates/enc/src/variable.rs
@@ -1,13 +1,10 @@
-use cir::{Condition, CIR};
-
-pub fn find(name: Variable, pattern: &[CIR], obj: &[CIR]) -> Option<CIR> {
-    let pos = pattern.iter().position(|ir| name == *ir)?;
-    obj.get(pos).copied()
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 pub enum Variable {
+    /// 0
+    Zero,
+    /// 1
+    One,
     /// label
     Label,
     /// Rn
@@ -32,94 +29,10 @@ pub enum Variable {
     Imm12,
     /// imm24
     Imm24,
-    /// P
-    IndexFlag,
-    /// U
-    UnsignedFlag,
-    /// W
-    WriteBackFlag,
-}
-
-impl Variable {
-    /// `value` comes from the obj, not the patterns
-    ///
-    /// # Panics
-    ///
-    /// If the pair are not encodable
-    pub fn encode_with_ir(&self, value: CIR) -> u32 {
-        match (&self, value) {
-            (Variable::Label, CIR::Label(adr)) => adr as u32,
-            (Variable::Rn, CIR::Register(x)) => x,
-            (Variable::Rm, CIR::Register(x)) => x,
-            (Variable::Rt, CIR::Register(x)) => x,
-            (Variable::Rd, CIR::Register(x)) => x,
-            (Variable::RegisterList, CIR::RegisterList(x)) => x as u32,
-            (Variable::Signed, CIR::Char('S')) => true as u32,
-            (Variable::Condition, CIR::Condition(cond)) => cond as u32,
-            (Variable::Stype, CIR::Shift(shift)) => match shift {
-                cir::Shift::LSL => 0b00,
-                cir::Shift::LSR => 0b01,
-                cir::Shift::ASR => 0b10,
-                cir::Shift::ROR => 0b11,
-                cir::Shift::RRX => 0b11,
-            },
-            (Variable::Imm5, CIR::Number(x)) => x,
-            (Variable::Imm12, CIR::Number(x)) => x,
-            (Variable::Imm24, CIR::Number(x)) => x,
-            (Variable::IndexFlag, CIR::OffsetAddress | CIR::PreIndexAddress) => true as u32,
-            // TODO: signs? U = 0 when negative
-            // for now all numbers are positive so U === 1
-            (Variable::UnsignedFlag, CIR::Number(_)) => true as u32,
-            (Variable::WriteBackFlag, CIR::PreIndexAddress) => true as u32,
-            _ => panic!("Pair not encodable"),
-        }
-    }
-
-    pub fn has_default(&self) -> Option<u32> {
-        match self {
-            Variable::Signed => Some(false as u32),
-            Variable::Condition => Some(self.encode_with_ir(CIR::Condition(Condition::AL))),
-            Variable::IndexFlag => Some(false as u32),
-            Variable::UnsignedFlag => Some(false as u32),
-            Variable::WriteBackFlag => Some(false as u32),
-            _ => None,
-        }
-    }
-}
-
-impl PartialEq<cir::CIR> for Variable {
-    fn eq(&self, other: &cir::CIR) -> bool {
-        const N: u32 = 'n' as u32;
-        const M: u32 = 'm' as u32;
-        const T: u32 = 't' as u32;
-        const D: u32 = 'd' as u32;
-
-        matches!(
-            (self, other),
-            (Variable::Label, CIR::Label(_))
-                | (Variable::Rn, CIR::Register(N))
-                | (Variable::Rm, CIR::Register(M))
-                | (Variable::Rt, CIR::Register(T))
-                | (Variable::Rd, CIR::Register(D))
-                | (Variable::RegisterList, CIR::RegisterList(_))
-                | (Variable::Signed, CIR::Char('S'))
-                | (Variable::Condition, CIR::Condition(_))
-                | (Variable::Stype, CIR::Shift(_))
-                | (Variable::Imm5, CIR::Number(_))
-                | (Variable::Imm12, CIR::Number(_))
-                | (Variable::Imm24, CIR::Number(_))
-                | (
-                    Variable::IndexFlag,
-                    CIR::OffsetAddress | CIR::PreIndexAddress
-                )
-                | (Variable::UnsignedFlag, CIR::Number(_))
-                | (Variable::WriteBackFlag, CIR::PreIndexAddress)
-        )
-    }
-}
-
-pub struct VariableDef {
-    pub(crate) name: Variable,
-    pub(crate) high: u8,
-    pub(crate) low: u8,
+    /// Index
+    P,
+    /// Unsigned / Positive
+    U,
+    /// Write Back
+    W,
 }


### PR DESCRIPTION
Fixes #9 

Remove old code for automatically searching through variables and replace `Schema` with a builder-like pattern.
