### PR TITLE
Lower conditional suffixes on instructions

### DIFF
--- a/crates/enc/src/schema.rs
+++ b/crates/enc/src/schema.rs
@@ -22,12 +22,6 @@ impl Schema {
         Self::default()
     }
 
-    pub fn cond(self) -> Self {
-        // FIXME: #3
-        // self.set(Variable::Condition, Value::Ref(2), 32, 28)
-        self.set(Variable::Condition, Condition::AL as u32, 32, 28)
-    }
-
     pub fn one(self, bit: u8) -> Self {
         self.set(Variable::One, 1, bit + 1, bit)
     }
@@ -58,6 +52,29 @@ impl Schema {
 impl Schema {
     pub(crate) fn variables(self) -> impl Iterator<Item = VariableDef> {
         self.map.into_iter()
+    }
+}
+
+pub fn cond(pos: usize, obj: &[CIR]) -> u32 {
+    let CIR::Condition(value) = obj[pos - 1] else {
+        panic!("No register at {}", pos)
+    };
+    match value {
+        Condition::EQ => 0b0000,
+        Condition::NE => 0b0001,
+        Condition::CS => 0b0010,
+        Condition::CC => 0b0011,
+        Condition::MI => 0b0100,
+        Condition::PL => 0b0101,
+        Condition::VS => 0b0110,
+        Condition::VC => 0b0111,
+        Condition::HI => 0b1000,
+        Condition::LS => 0b1001,
+        Condition::GE => 0b1010,
+        Condition::LT => 0b1011,
+        Condition::GT => 0b1100,
+        Condition::LE => 0b1101,
+        Condition::AL => 0b1110,
     }
 }
 

--- a/crates/enc/src/schema.rs
+++ b/crates/enc/src/schema.rs
@@ -57,7 +57,7 @@ impl Schema {
 
 pub fn cond(pos: usize, obj: &[CIR]) -> u32 {
     let CIR::Condition(value) = obj[pos - 1] else {
-        panic!("No register at {}", pos)
+        panic!("No conditional at {}", pos)
     };
     match value {
         Condition::EQ => 0b0000,

--- a/crates/enc/src/tests/data.rs
+++ b/crates/enc/src/tests/data.rs
@@ -9,6 +9,7 @@ impl Pattern for AddImm {
             Char('A'),
             Char('D'),
             Char('D'),
+            Condition(cir::Condition::AL),
             Register('d' as u32),
             Register('n' as u32),
             Number(u32::MAX),
@@ -20,13 +21,13 @@ impl Pattern for AddImm {
 impl Encodable for AddImm {
     fn schema(&self, obj: &[CIR]) -> Schema {
         Schema::new()
-            .cond()
+            .set(Variable::Condition, cond(4, obj), 32, 28)
             .one(25)
             .one(23)
             .bit(Variable::Signed, obj[4] == CIR::Char('S'), 20)
-            .set(Variable::Rn, reg(5, obj), 20, 16)
-            .set(Variable::Rd, reg(4, obj), 16, 12)
-            .set(Variable::Imm12, imm12(6, obj), 12, 0)
+            .set(Variable::Rn, reg(6, obj), 20, 16)
+            .set(Variable::Rd, reg(5, obj), 16, 12)
+            .set(Variable::Imm12, imm12(7, obj), 12, 0)
     }
 }
 

--- a/crates/enc/src/tests/load_store.rs
+++ b/crates/enc/src/tests/load_store.rs
@@ -9,6 +9,7 @@ impl Pattern for LdrImmPreIndex {
             Char('L'),
             Char('D'),
             Char('R'),
+            Condition(cir::Condition::AL),
             Register('t' as u32),
             PreIndexAddress,
             Register('n' as u32),
@@ -21,16 +22,16 @@ impl Pattern for LdrImmPreIndex {
 impl Encodable for LdrImmPreIndex {
     fn schema(&self, obj: &[CIR]) -> Schema {
         Schema::new()
-            .cond()
+            .set(Variable::Condition, cond(4, obj), 32, 28)
             .one(26)
             .bit(Variable::P, true, 24)
             // FIXME: check if imm12 has a '-' sign
             .bit(Variable::U, true, 23)
             .bit(Variable::W, true, 21)
             .one(20)
-            .set(Variable::Rn, reg(6, obj), 20, 16)
-            .set(Variable::Rt, reg(4, obj), 16, 12)
-            .set(Variable::Imm12, imm12(7, obj), 12, 0)
+            .set(Variable::Rn, reg(7, obj), 20, 16)
+            .set(Variable::Rt, reg(5, obj), 16, 12)
+            .set(Variable::Imm12, imm12(8, obj), 12, 0)
     }
 }
 
@@ -57,6 +58,7 @@ impl Pattern for LdrRegPreIndex {
             Char('L'),
             Char('D'),
             Char('R'),
+            Condition(cir::Condition::AL),
             Register('t' as u32),
             PreIndexAddress,
             Register('n' as u32),
@@ -71,7 +73,7 @@ impl Pattern for LdrRegPreIndex {
 impl Encodable for LdrRegPreIndex {
     fn schema(&self, obj: &[CIR]) -> Schema {
         Schema::new()
-            .cond()
+            .set(Variable::Condition, cond(4, obj), 32, 28)
             .one(26)
             .one(25)
             .bit(Variable::P, true, 24)
@@ -79,11 +81,11 @@ impl Encodable for LdrRegPreIndex {
             .bit(Variable::U, true, 23)
             .bit(Variable::W, true, 21)
             .one(20)
-            .set(Variable::Rn, reg(6, obj), 20, 16)
-            .set(Variable::Rt, reg(4, obj), 16, 12)
-            .set(Variable::Imm5, imm5(9, obj), 12, 7)
-            .set(Variable::Stype, stype(8, obj), 7, 5)
-            .set(Variable::Rm, reg(7, obj), 4, 0)
+            .set(Variable::Rn, reg(7, obj), 20, 16)
+            .set(Variable::Rt, reg(5, obj), 16, 12)
+            .set(Variable::Imm5, imm5(10, obj), 12, 7)
+            .set(Variable::Stype, stype(9, obj), 7, 5)
+            .set(Variable::Rm, reg(8, obj), 4, 0)
     }
 }
 
@@ -110,6 +112,7 @@ impl Pattern for LdrImmLit {
             Char('L'),
             Char('D'),
             Char('R'),
+            Condition(cir::Condition::AL),
             Register('t' as u32),
             Label(i32::MAX),
         ];
@@ -119,17 +122,17 @@ impl Pattern for LdrImmLit {
 
 impl Encodable for LdrImmLit {
     fn schema(&self, obj: &[CIR]) -> Schema {
-        let (label, u) = label(5, obj);
+        let (label, u) = label(6, obj);
 
         Schema::new()
-            .cond()
+            .set(Variable::Condition, cond(4, obj), 32, 28)
             .one(26)
             .bit(Variable::P, true, 24)
             .bit(Variable::U, u, 23)
             .bit(Variable::W, false, 21)
             .one(20)
             .set(Variable::Rn, 0b1111, 20, 16)
-            .set(Variable::Rt, reg(4, obj), 16, 12)
+            .set(Variable::Rt, reg(5, obj), 16, 12)
             .set(Variable::Label, label, 12, 0)
     }
 }

--- a/crates/enc/src/tests/multi_load_store.rs
+++ b/crates/enc/src/tests/multi_load_store.rs
@@ -9,6 +9,7 @@ impl Pattern for Ldm {
             Char('L'),
             Char('D'),
             Char('M'),
+            Condition(cir::Condition::AL),
             Register('n' as u32),
             RegisterList(u16::MAX),
         ];
@@ -19,13 +20,13 @@ impl Pattern for Ldm {
 impl Encodable for Ldm {
     fn schema(&self, obj: &[CIR]) -> Schema {
         Schema::new()
-            .cond()
+            .set(Variable::Condition, cond(4, obj), 32, 28)
             .one(27)
             .one(23)
             .bit(Variable::W, false, 21)
             .one(20)
-            .set(Variable::Rn, reg(4, obj), 20, 16)
-            .set(Variable::RegisterList, register_list(5, obj), 16, 0)
+            .set(Variable::Rn, reg(5, obj), 20, 16)
+            .set(Variable::RegisterList, register_list(6, obj), 16, 0)
     }
 }
 

--- a/crates/hand/src/lowering/cir.rs
+++ b/crates/hand/src/lowering/cir.rs
@@ -37,6 +37,23 @@ impl<'a> HANDCursor<'a> {
                     }
                     continue;
                 }
+                Fragment::Condition(cond) => CIR::Condition(match cond {
+                    super::Condition::EQ => cir::Condition::EQ,
+                    super::Condition::NE => cir::Condition::NE,
+                    super::Condition::CS => cir::Condition::CS,
+                    super::Condition::CC => cir::Condition::CC,
+                    super::Condition::MI => cir::Condition::MI,
+                    super::Condition::PL => cir::Condition::PL,
+                    super::Condition::VS => cir::Condition::VS,
+                    super::Condition::VC => cir::Condition::VC,
+                    super::Condition::HI => cir::Condition::HI,
+                    super::Condition::LS => cir::Condition::LS,
+                    super::Condition::GE => cir::Condition::GE,
+                    super::Condition::LT => cir::Condition::LT,
+                    super::Condition::GT => cir::Condition::GT,
+                    super::Condition::LE => cir::Condition::LE,
+                    super::Condition::AL => cir::Condition::AL,
+                }),
                 Fragment::Register(r) => CIR::Register(r),
                 Fragment::RegisterList(rl) => CIR::RegisterList(rl),
                 Fragment::Number(num) => CIR::Number(num),


### PR DESCRIPTION
Matches against suffixes on the names of instructions to find conditionals.
Conditional values are then lowered to CIR always,

This allows the additional of conditional values to be matched and encoded.